### PR TITLE
Fix broken link to ExtJS 3.4 docs in README

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -39,7 +39,7 @@ Returns the raw ExtJS source directory.
 
 =item * L<www.sencha.com|http://www.sencha.com>
 
-=item * L<ExtJS 3.4.0 API Docs|http://dev.sencha.com/deploy/ext-3.4.0/docs/>
+=item * L<ExtJS 3.4.0 API Docs|https://docs.sencha.com/extjs/3.4.0/>
 
 =back
 


### PR DESCRIPTION
Update link to ExtJS 3.4 doco (which has moved (and been buried))